### PR TITLE
Reduce amount of queries

### DIFF
--- a/lib/Anh/Taggable/Entity/Tagging.php
+++ b/lib/Anh/Taggable/Entity/Tagging.php
@@ -17,7 +17,7 @@ class Tagging extends MappedSuperclass\AbstractTagging
     /**
      * @var $tag
      *
-     * @ORM\ManyToOne(targetEntity="Tag", inversedBy="tagging")
+     * @ORM\ManyToOne(targetEntity="Tag", inversedBy="tagging", fetch="EAGER")
      * @ORM\JoinColumn(name="tagId", referencedColumnName="id")
      */
     protected $tag;


### PR DESCRIPTION
When listing some rows of a taggable entity, which should also contain its related tags, it creates way more queries then necessary. 

It first queries all entity rows. Then, for each row, it queries the related Tagging rows. When the entity has tags, it queries the Tag rows related to the Tagging rows.

I think there should be a way to somehow join the Tagging & Tag tables to the taggable entity. The commit already reduces the part between Tagging & Tag, but I haven't been able to create a solution between the Entity & Tagging tables yet. The problem I encountered was the fact that there's no hard relation between the entity and the Tagging table, which makes it hard to do joins.

I was thinking about creating an abstract TaggableRepository, which has something like findWithTags() method. Then, the each taggable entity's repository could extend from this repository.

Any suggestions?
