### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $taggableManager = new TaggableManager(
     $em, 'Anh\Taggable\Entity\Tag', 'Anh\Taggable\Entity\Tagging'
 );
 
-// add event subscriber
+// add event subscriber (only if you didn't before in services.yml)
 $em->getEventManager()->addEventSubscriber(
     new TaggableSubscriber($taggableManager)
 );


### PR DESCRIPTION
In example the event subscriber should be only added if user didn't this before in services.yml, otherwise query gets executed twice and you get a duplicate key error.
